### PR TITLE
Add codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+---
+engines:
+  csslint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - javascript
+      - php
+  eslint:
+    enabled: true
+  fixme:
+    enabled: true
+  phpmd:
+    enabled: true
+ratings:
+  paths:
+  - "**.css"
+  - "**.js"
+  - "**.php"
+exclude_paths: []

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.codeclimate.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
Add a codeclimate config to the repository. Codeclimate runs linters for
multiple languages, and can also intergrate with coverage using
travis-ci to run the coverage tests.

You can find the codeclimate for this repository here:
 https://codeclimate.com/github/failmap/website
